### PR TITLE
Add missing return in Template::send.

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -95,7 +95,7 @@ class Template
         {
             $instance = app()->make(static::class);
             call_user_func($callable, $instance);
-            $instance->send($template_id);
+            return $instance->send($template_id);
         }
         else
             return $this->transport->send($template_id, $this);


### PR DESCRIPTION
In order to fix error: `Return value of Juanparati\Sendinblue\Template::send() must be of the type string, none returned`, I added a return into the first condition `return $instance->send($template_id);`.

Error can be reproduce by sending a message using template and a callable:
```php
MailTemplate::send(1, function ($message) {
	$message->to('test@example.org');
	$message->attributes(['BODY' => 'one']);
});
```